### PR TITLE
restore-mtime: Fix exception caused by renames

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -249,7 +249,11 @@ def parselog(merge=False, filterlist=[]):
 
         # File line
         if line.startswith(':'):
-            status, file = line.split('\t')
+            # If line describes a rename, linetok has three tokens, otherwise
+            # two.
+            linetok = line.split('\t')
+            status = linetok[0]
+            file = linetok[-1]
 
             # Make sure the slash matches the os; for Windows we need a backslash
             if not os.sep == '/':


### PR DESCRIPTION
When files are renamed, the corresponding line in the $(git whatchanged)
output contains three tokens separated by '\t'. This caused a
"ValueError: too many values to unpack" error.