### PR TITLE
restore-mtime: Fix restoring mtime for directories

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -197,7 +197,6 @@ for path in args.pathspec:
                 filelist.add(os.path.relpath(os.path.join(root, file), workdir))
 
 filelist &= lsfileslist
-dirlist &= lsfileslist
 
 totaldirs  = dirs  = len(dirlist)
 totalfiles = files = len(filelist)


### PR DESCRIPTION
Commit 27863ac5 restricts the set of files and directories to be
processed by the output of $(git ls-files). But since the latter outputs
files only, the set of directories got emptied.