### PR TITLE
git-restore-mtime: fix for py3

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -150,7 +150,7 @@ gitobj = subprocess.Popen(gitcmd + shlex.split('ls-files --full-name') +
                           ['--'] + args.pathspec,
                           stdout=subprocess.PIPE)
 for line in gitobj.stdout:
-    lsfileslist.add(os.path.relpath(line.strip(), workdir))
+    lsfileslist.add(os.path.relpath(text(line.strip()), workdir))
 
 # List files matching user pathspec, relative to current directory
 # git commands always print paths relative to work tree root


### PR DESCRIPTION
In py3, subprocess output is bytes, but os.path.relpath() is expecting a
string, so pass it through text() to ensure it's a string.

(Merge this before fixing #15, @robbat2 will appreciate it)
