### PR TITLE
Fix misspelled instances of uncommitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Useful for creating a new repository out of a set of files from another reposito
 
 
 git-find-uncommitted-repos
--------------------------
+--------------------------
 
 *Recursively list repos with uncommitted changes*
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Clones a `repository` into a `destination` directory and runs on the clone `git 
 Useful for creating a new repository out of a set of files from another repository, migrating (only) their associated history. Very similar to what `git filter-branch --subdirectory-filter` does, but for a file pattern instead of just a single directory.
 
 
-git-find-uncommited-repos
+git-find-uncommitted-repos
 -------------------------
 
-*Recursively list repos with uncommited changes*
+*Recursively list repos with uncommitted changes*
 
-Recursively finds all git repositories in the given directory(es), runs `git status` on them, and prints the location of reposities with uncommited changes. The tool I definitely use the most.
+Recursively finds all git repositories in the given directory(es), runs `git status` on them, and prints the location of reposities with uncommitted changes. The tool I definitely use the most.
 
 
 git-rebase-theirs

--- a/git-find-uncommitted-repos
+++ b/git-find-uncommitted-repos
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# git-find-uncommited-repos - recursively list repos with uncommited changes
+# git-find-uncommitted-repos - recursively list repos with uncommitted changes
 #
 #    Copyright (C) 2012 Rodrigo Silva (MestreLion) <linux@rodrigosilva.com>
 #
@@ -18,7 +18,7 @@
 #    along with this program. See <http://www.gnu.org/licenses/gpl.html>
 #
 # Recursively finds all git repositories in each PATH argument, runs git status
-# on them, and prints the location of reposities with uncommited changes
+# on them, and prints the location of reposities with uncommitted changes
 # Only works for conventional repositories where git dir is "<work-tree>/.git"
 
 myname="${0##*/}"
@@ -39,13 +39,13 @@ usage() {
 	fi
 	cat <<-USAGE
 
-	Recursively list repositories with uncommited changes
+	Recursively list repositories with uncommitted changes
 
 	Options:
 	  -h|--help      - show this page.
 	  -v|--verbose   - print more details about what is being done.
 
-	  -u|--untracked - count untracked files as 'uncommited'
+	  -u|--untracked - count untracked files as 'uncommitted'
 
 	  DIR...         - the directories to scan, or current directory if none
 	                   is specified.
@@ -73,6 +73,6 @@ dirs+=( "$@" )
 
 while read -r repo; do
 	repo="$(dirname "$repo")"
-	uncommited=$(cd "$repo"; git status --short --untracked-files="$untracked")
-	[[ "$uncommited" ]] && echo "$repo"
+	uncommitted=$(cd "$repo"; git status --short --untracked-files="$untracked")
+	[[ "$uncommitted" ]] && echo "$repo"
 done < <(find "${dirs[@]}" -name .git -type d)

--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -26,7 +26,7 @@
 # (assuming the actual modification date and its commit date are close)
 
 # By default ignores all ignored and untracked files, and also refuses to work
-# on trees with uncommited changes.
+# on trees with uncommitted changes.
 
 if __name__ != "__main__":
     raise ImportError("%s should not be used as a module." % __name__)
@@ -60,7 +60,7 @@ parser.add_argument('--verbose', '-v',
 
 parser.add_argument('--force', '-f',
                     action="store_true",
-                    help='force execution on trees with uncommited changes.')
+                    help='force execution on trees with uncommitted changes.')
 
 parser.add_argument('--merge', '-m',
                     action="store_true",


### PR DESCRIPTION
I'd like to package this set of scripts for Fedora and RHEL/CentOS systems, and am in the process of formatting manpage equivalents to the --help output that each command produces.  Noticed this misspelled word and thought it would make sense to fix it before manpages are added.
