### PR TITLE
Add some manpages for distribution packaging

### DIFF
--- a/man1/git-branches-rename.1
+++ b/man1/git-branches-rename.1
@@ -1,0 +1,44 @@
+.TH GIT-BRANCHES-RENAME 1 2016-01-31
+.\" For nroff, turn off justification.  Always turn off hyphenation; it makes
+.\" way too many mistakes in technical documents.
+.if n .ad l
+.nh
+.SH NAME
+git-branches-rename \-
+Batch renames branches with a matching prefix to another prefix
+.SH SYNOPSIS
+.B git-branches-rename
+.RI [ options ]
+.I BRANCH_PREFIX NEW_PREFIX
+.SH DESCRIPTION
+Batch renames branches with a matching prefix to another prefix.
+.SH OPTIONS
+.TP 8
+.BR \-h , \ \-\-help
+show usage information.
+.TP 8
+.BR \-v , \ \-\-verbose
+print more details about what is being done.
+.TP 8
+.BR \-n , \ \-\-dry-run
+do not actually rename the branches.
+.TP 8
+.I BRANCH_PREFIX
+a prefix that matches the start of branch names.
+.TP 8
+.I NEW_PREFIX
+the new prefix for the branch names.
+.SH EXAMPLES
+.nf
+$ git-rename-branches bug bugfix
+bug/128  -> bugfix/128
+bug_test -> bugfix_test
+
+$ git-rename-branches ma backup/ma
+master -> backup/master
+main   -> backup/main
+.fi
+.SH SEE ALSO
+.B https://github.com/MestreLion/git-tools
+.SH AUTHOR
+Rodrigo Silva (MestreLion) linux@rodrigosilva.com

--- a/man1/git-clone-subset.1
+++ b/man1/git-clone-subset.1
@@ -1,0 +1,87 @@
+.TH GIT-CLONE-SUBSET 1 2016-01-31
+.\" For nroff, turn off justification.  Always turn off hyphenation; it makes
+.\" way too many mistakes in technical documents.
+.if n .ad l
+.nh
+.SH NAME
+git-clone-subset \-
+Clones a subset of a git repository
+.SH SYNOPSIS
+.B git-clone-subset
+.RI [ options ]
+.I repository destination-dir pattern
+.SH DESCRIPTION
+Clones a
+.I repository
+into a
+.I destination-dir
+and runs on the clone
+.br
+.B git filter-branch --prune-empty --tree-filter 'git rm ...' -- --all
+.br
+to prune from history all files except the ones matching
+.IR pattern ,
+effectively creating a clone with a subset of files (and history) of the
+original repository.
+.sp
+Useful for creating a new repository out of a set of files from another
+repository, migrating (only) their associated history. Very similar to
+what
+.br
+.B git filter-branch --subdirectory-filter
+.br
+does, but for a file
+pattern instead of just a single directory.
+.SH OPTIONS
+.TP 8
+.BR \-h , \ \-\-help
+show usage information.
+.TP 8
+.I repository
+URL or local path to the git repository to be cloned.
+.TP 8
+.I destination-dir
+Directory to create the clone. Same rules for git-clone applies: it
+will be created if it does not exist and it must be empty otherwise.
+But, unlike git-clone, this argument is not optional: git-clone uses
+several rules to determine the "Humane" dir name of a cloned repo,
+and git-clone-subset will not risk parse its output, let alone
+predict the chosen name.
+.TP 8
+.I pattern
+Glob pattern to match the desired files/dirs. It will be ultimately
+evaluated by a call to bash, NOT git or sh, using extended glob
+'!(<pattern>)' rule. Quote it or escape it on command line, so it
+does not get evaluated prematurely by your current shell. Only a
+single pattern is allowed: if more are required, use extglob's "|"
+syntax. Globs will be evaluated with bash's shopt dotglob set, so
+beware. Patterns should not contain spaces or special chars like
+" ' $ ( ) { } `, not even quoted or escaped, since that might
+interphere with the !() syntax after pattern expansion.
+.sp
+Pattern Examples:
+.sp
+"*.png"
+.br
+"*.png|*icon*"
+.br
+"*.h|src/|lib"
+.SH LIMITATIONS
+Renames are NOT followed. As a workaround, list the rename history with
+'git log --follow --name-status --format='%H' -- file | grep "^[RAD]"'
+and include all multiple names of a file in the pattern, as in
+"currentname|oldname|initialname". As a side efect, if a different
+file has taken place of an old name, it will be preserved too, and
+there is no way around this using this tool.
+.sp
+There is no (easy) way to keep some files in a dir: using 'dir/foo*'
+as pattern will not work. So keep the whole dir and remove files
+afterwards, using git filter-branch and a (quite complex) combination
+of cloning, remote add, rebases, etc.
+.sp
+Pattern matching is quite limited, and many of bash's escaping and
+quoting does not work properly when pattern is expanded inside !().
+.SH SEE ALSO
+.B https://github.com/MestreLion/git-tools
+.SH AUTHOR
+Rodrigo Silva (MestreLion) linux@rodrigosilva.com

--- a/man1/git-find-uncommitted-repos.1
+++ b/man1/git-find-uncommitted-repos.1
@@ -1,0 +1,30 @@
+.TH GIT-FIND-UNCOMMITTED-REPOS 1 2016-01-31
+.\" For nroff, turn off justification.  Always turn off hyphenation; it makes
+.\" way too many mistakes in technical documents.
+.if n .ad l
+.nh
+.SH NAME
+git-find-uncommitted-repos \-
+Recursively list repositories with uncommitted changes
+.SH SYNOPSIS
+.B git-find-uncommitted-repos
+.RI [ DIR ...]
+.SH DESCRIPTION
+Recursively list repositories with uncommitted changes.
+.SH OPTIONS
+.TP 8
+.BR \-h , \ \-\-help
+show usage information.
+.TP 8
+.BR \-v , \ \-\-verbose
+print more details about what is being done.
+.TP 8
+.BR \-u , \ \-\-untracked
+count untracked files as 'uncommitted'
+.TP 8
+.IR DIR ...
+the directories to scan, or current directory if none is specified.
+.SH SEE ALSO
+.B https://github.com/MestreLion/git-tools
+.SH AUTHOR
+Rodrigo Silva (MestreLion) linux@rodrigosilva.com

--- a/man1/git-rebase-theirs.1
+++ b/man1/git-rebase-theirs.1
@@ -1,0 +1,49 @@
+.TH GIT-REBASE-THEIRS 1 2016-01-31
+.\" For nroff, turn off justification.  Always turn off hyphenation; it makes
+.\" way too many mistakes in technical documents.
+.if n .ad l
+.nh
+.SH NAME
+git-rebase-theirs \-
+Resolve rebase conflicts and failed cherry-picks by favoring 'theirs' version
+.SH SYNOPSIS
+.B git-rebase-theirs
+.RI [ options ]
+.RI [ -- ]
+.IR FILE ...
+.SH DESCRIPTION
+Resolve git rebase conflicts in FILE(s) by favoring 'theirs' version.
+
+When using git rebase, conflicts are usually wanted to be resolved
+by favoring the <working branch> version (the branch being rebased,
+'theirs' side in a rebase), instead of the <upstream> version (the
+base branch, 'ours' side)
+
+But git rebase --strategy -X theirs is only available from git 1.7.3
+For older versions, git-rebase-theirs is the solution. And Despite the name,
+it's also useful for fixing failed cherry-picks.
+
+It works by discarding all lines between '<<<<<<< ' and '========'
+inclusive, and also the the '>>>>>> commit' marker.
+
+By default it outputs to stdout, but files can be edited in-place
+using --in-place, which, unlike sed, creates a backup by default.
+.SH OPTIONS
+.TP 8
+.BR \-h , \ \-\-help
+show usage information.
+.TP 8
+.BR \-v , \ \-\-verbose
+print more details in stderr.
+.TP 8
+.BI \-\-in-place [=SUFFIX]
+edit files in place, creating a backup with
+.I SUFFIX
+extension. Default if blank is ".bak"
+.TP 8
+.B \-\-no-backup
+disables backup
+.SH SEE ALSO
+.B https://github.com/MestreLion/git-tools
+.SH AUTHOR
+Rodrigo Silva (MestreLion) linux@rodrigosilva.com

--- a/man1/git-restore-mtime-core.1
+++ b/man1/git-restore-mtime-core.1
@@ -1,0 +1,41 @@
+.TH GIT-RESTORE-MTIME-CORE 1 2016-01-31
+.\" For nroff, turn off justification.  Always turn off hyphenation; it makes
+.\" way too many mistakes in technical documents.
+.if n .ad l
+.nh
+.SH NAME
+git-restore-mtime-core \-
+Restore original modification time of files based on the date of the most
+recent commit that modified them
+.SH SYNOPSIS
+.B git-restore-mtime-core
+.RB [ -h ]
+.RB [ --verbose ]
+.RB [ --merge ]
+.RI [ pathspec
+.RI [ pathspec ...]]
+.SH DESCRIPTION
+Restore original modification time of files based on the date of the most
+recent commit that modified them. Useful when generating release tarballs.
+Current directory must be inside work tree.
+.SH OPTIONS
+.SS Positional arguments:
+.TP 8
+.I pathspec
+only modify paths (dirs or files) matching PATHSPEC,
+absolute or relative to current directory. Default is
+current directory.
+.SS Optional arguments:
+.TP 8
+.BR \-h , \ \-\-help
+show help message and exit
+.TP 8
+.BR \-\-verbose , \-v
+print warnings and debug info for each processed file.
+.TP 8
+.BR \-\-merge , \-m
+include merge commits.
+.SH SEE ALSO
+.B https://github.com/MestreLion/git-tools
+.SH AUTHOR
+Rodrigo Silva (MestreLion) linux@rodrigosilva.com

--- a/man1/git-restore-mtime.1
+++ b/man1/git-restore-mtime.1
@@ -19,6 +19,7 @@ recent commit that modified them
 .RB [ --skip-missing ]
 .RB [ --no-directories ]
 .RB [ --test ]
+.RB [ --commit-time ]
 .br
 .RB [ --work-tree
 .IR WORKDIR ]
@@ -79,6 +80,9 @@ will not update its directory mtime.
 .TP 8
 .BR \-\-test , \-t
 test run: do not actually update any file
+.TP 8
+.BR \-\-commit-time , \-c
+use commit time instead of author time
 .TP 8
 .BI \-\-work-tree\  WORKDIR
 specify where the work tree is. Default for most

--- a/man1/git-restore-mtime.1
+++ b/man1/git-restore-mtime.1
@@ -1,0 +1,93 @@
+.TH GIT-RESTORE-MTIME 1 2016-01-31
+.\" For nroff, turn off justification.  Always turn off hyphenation; it makes
+.\" way too many mistakes in technical documents.
+.if n .ad l
+.nh
+.SH NAME
+git-restore-mtime \-
+Restore original modification time of files based on the date of the most
+recent commit that modified them
+.SH SYNOPSIS
+.TP 18
+.B git-restore-mtime
+.RB [ -h ]
+.RB [ --quiet ]
+.RB [ --verbose ]
+.RB [ --force ]
+.RB [ --merge ]
+.br
+.RB [ --skip-missing ]
+.RB [ --no-directories ]
+.RB [ --test ]
+.br
+.RB [ --work-tree
+.IR WORKDIR ]
+.RB [ --git-dir
+.IR GITDIR ]
+.br
+.RI [ pathspec
+.RI [ pathspec ...]]
+.SH DESCRIPTION
+Restore original modification time of files based on the date of the most
+recent commit that modified them. Useful when generating release tarballs.
+.SH OPTIONS
+.SS Positional arguments:
+.TP 8
+.I pathspec
+only modify paths (dirs or files) matching PATHSPEC,
+relative to current directory. Default is to modify
+all non-ignored, tracked files.
+.SS Optional arguments:
+.TP 8
+.BR \-h , \ \-\-help
+show help message and exit
+.TP 8
+.BR \-\-quiet , \-q
+suppress informative messages and summary statistics.
+.TP 8
+.BR \-\-verbose , \-v
+print additional information for each processed file.
+Overwrites --quiet.
+.TP 8
+.BR \-\-force , \-f
+force execution on trees with uncommitted changes.
+.TP 8
+.BR \-\-merge , \-m
+include merge commits. Leads to more recent mtimes and
+more files per commit, thus with the same mtime (which
+may or may not be what you want). Including merge
+commits may lead to less commits being evaluated (all
+files are found sooner), which improves performance,
+sometimes substantially. But since merge commits are
+usually huge, processing them may also take longer,
+sometimes substantially. By default merge logs are
+only used for files missing from regular commit logs.
+.TP 8
+.BR \-\-skip-missing , \-s
+do not try to find missing files. If some files were
+not found in regular commit logs, by default it
+retries using merge commit logs for these files (if
+--merge was not used already). This option disables
+this behavior, which may slightly improve performance,
+but files found only in merge commits will not be
+updated.
+.TP 8
+.BR \-\-no-directories , \-D
+do not update directory mtime for files created,
+renamed or deleted in it. Note: just modifying a file
+will not update its directory mtime.
+.TP 8
+.BR \-\-test , \-t
+test run: do not actually update any file
+.TP 8
+.BI \-\-work-tree\  WORKDIR
+specify where the work tree is. Default for most
+repositories is current directory.
+.TP 8
+.BI \-\-git-dir\  GITDIR
+specify where the git repository is. Default for most
+repositories <work-tree>/.git
+.SH SEE ALSO
+.B https://github.com/MestreLion/git-tools
+.SH AUTHOR
+Rodrigo Silva (MestreLion) linux@rodrigosilva.com

--- a/man1/git-strip-merge.1
+++ b/man1/git-strip-merge.1
@@ -1,0 +1,63 @@
+.TH GIT-STRIP-MERGE 1 2016-01-31
+.\" For nroff, turn off justification.  Always turn off hyphenation; it makes
+.\" way too many mistakes in technical documents.
+.if n .ad l
+.nh
+.SH NAME
+git-strip-merge \-
+A git-merge wrapper that deletes files on a "foreign" branch before merging
+.SH SYNOPSIS
+.B git-strip-merge
+.RI [ git-merge\ options ]
+.RB [ -M
+.IR <commitmsg> ]
+.I <branch>
+.IR FILE ...
+.SH DESCRIPTION
+git-merge that deletes files on "foreign" <branch> before merging.
+.sp
+Useful for ignoring a folder in <branch> before merging it with
+current branch. Works by deleting FILE(S) in a detached commit based
+on <branch>, and then performing the merge of this new commit in the
+current branch. Note that <branch> is not changed by this procedure.
+Also note that <branch> may actually be any reference, like a tag,
+or a remote branch, or even a commit SHA.
+.sp
+For more information, see <http://stackoverflow.com/questions/3111515>
+.SH OPTIONS
+.TP 8
+.BR \-h , \ \-\-help
+show help message and exit
+.TP 8
+.BR \-v , \ \-\-verbose
+do not use -q to supress normal output of internal steps from git
+checkout, rm, commit. By default, only git merge output is shown.
+Errors, however, are never supressed.
+.TP 8
+.BR \-M\  <message>, \ \-\-msgcommit =<message>
+message for the removal commit in <branch>. Not to be confused
+with the message of the merge commit, which is set by -m. Default
+message is: "remove files from '<branch>' before merge".
+.TP 8
+.BR \-m\  <message>, \ \-\-message =<message>
+message for the merge commit. Since we are not merging <branch>
+directly, but rather a detached commit based on it, we forge a
+message similar to git's default for a branch merge. Otherwise
+git would use in message the full and ugly SHA1 of our commit.
+Default message is: "Merge stripped branch '<branch>'".
+.PP
+For both commit messages, the token "<branch>" is replaced for the
+actual <branch> name.
+.sp
+Additional options are passed unchecked to git merge.
+.sp
+All options must precede <branch> and FILE(s), except -h and --help
+that may appear anywhere on the command line.
+.SH EXAMPLE
+.nf
+git-strip-merge design "photoshop/*"
+.fi
+.SH SEE ALSO
+.B https://github.com/MestreLion/git-tools
+.SH AUTHOR
+Rodrigo Silva (MestreLion) linux@rodrigosilva.com


### PR DESCRIPTION
I unfortunately didn't see the comment from @kilobyte about manpages that had already been written for Debian packaging before doing these.  I think they're (obviously) fairly similar, although I tried to use some of the bold and italics in the synopsis sections, and I separated the OPTIONS into a separate header.  Whether we eventually use @kilobyte 's file or mine, I doubt it matters but I think it makes more sense for them to be located under "man1", "manpages" or similar vs. "debian".  Thoughts?