### PR TITLE
git-restore-mtime: add flag to allow using commit time

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -93,6 +93,10 @@ parser.add_argument('--test', '-t',
                     action="store_true", default=False, dest='test',
                     help='test run: do not actually update any file')
 
+parser.add_argument('--commit-time', '-c',
+                    action='store_const', const='%ct', default='%at', dest='timeformat',
+                    help='use commit time instead of author time')
+
 parser.add_argument('pathspec',
                     nargs='*', default=[os.path.curdir],
                     help='only modify paths (dirs or files) matching PATHSPEC, '
@@ -246,7 +250,7 @@ logger.debug("Line #\tLog #\tFiles\tmtime\tFile")
 def parselog(merge=False, filterlist=[]):
     global loglines, dirs, files, touches, errors, commits
 
-    gitobj = subprocess.Popen(gitcmd + shlex.split('whatchanged --pretty=%at') +
+    gitobj = subprocess.Popen(gitcmd + shlex.split('whatchanged --pretty={}'.format(args.timeformat)) +
                               (['-m'] if merge else []) +
                               ['--'] + filterlist,
                               stdout=subprocess.PIPE)


### PR DESCRIPTION
This allows using commit time for mtimes, which is often more
monotonically increasing.