### PR TITLE
restore-mtime: Add option to pass --first-parent to git whatchanged

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -74,6 +74,14 @@ parser.add_argument('--merge', '-m',
                         'sometimes substantially. By default merge logs are only '
                         'used for files missing from regular commit logs.')
 
+parser.add_argument('--first-parent',
+                    action="store_true",
+                    help='pass --first-parent to git whatchanged to hide the '
+                        'second parent from the merge commit logs. Only has any '
+                        'effect if --merge is also specified or --skip-missing '
+                        'is not specified and there were files not found in regular '
+                        'commit logs.')
+
 parser.add_argument('--skip-missing', '-s',
                     action="store_false", default=True, dest='missing',
                     help='do not try to find missing files. If some files were '
@@ -252,6 +260,7 @@ def parselog(merge=False, filterlist=[]):
 
     gitobj = subprocess.Popen(gitcmd + shlex.split('whatchanged --pretty={}'.format(args.timeformat)) +
                               (['-m'] if merge else []) +
+                              (['--first-parent'] if args.first_parent else []) +
                               ['--'] + filterlist,
                               stdout=subprocess.PIPE)
     for line in gitobj.stdout:

--- a/man1/git-restore-mtime.1
+++ b/man1/git-restore-mtime.1
@@ -15,6 +15,7 @@ recent commit that modified them
 .RB [ --verbose ]
 .RB [ --force ]
 .RB [ --merge ]
+.RB [ --first-parent ]
 .br
 .RB [ --skip-missing ]
 .RB [ --no-directories ]
@@ -63,6 +64,13 @@ sometimes substantially. But since merge commits are
 usually huge, processing them may also take longer,
 sometimes substantially. By default merge logs are
 only used for files missing from regular commit logs.
+.TP 8
+.BR \-\-first-parent
+pass --first-parent to git whatchanged to hide the
+second parent from the merge commit logs. Only has any
+effect if --merge is also specified or --skip-missing
+is not specified and there were files not found in
+regular commit logs.
 .TP 8
 .BR \-\-skip-missing , \-s
 do not try to find missing files. If some files were


### PR DESCRIPTION
In some rare cases, we don't want git to show second parent in the merge
commit logs, so allow passing --first-parent through to git whatchanged
to hide that.