### PR TITLE
git-restore-mtime: skip symlinks if the OS does not support updating them

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -37,6 +37,15 @@ import logging as logger
 import argparse
 import time
 
+if os.utime in getattr(os, 'supports_follow_symlinks', []):
+    def lutime(path, times):
+        os.utime(path, times, follow_symlinks=False)
+else:
+    def lutime(path, times):
+        if os.path.islink(path):
+            raise Warning('Unable to update symlink: ' + path)
+        os.utime(path, times)
+
 parser = argparse.ArgumentParser(
     description='Restore original modification time of files based on '
                 'the date of the most recent commit that modified them. '
@@ -287,7 +296,7 @@ def parselog(merge=False, filterlist=[]):
                 files -= 1
                 try:
                     if not args.test:
-                        os.utime(os.path.join(workdir, file), (mtime, mtime))
+                        lutime(os.path.join(workdir, file), (mtime, mtime))
                     touches += 1
                 except Exception as e:
                     logger.error("ERROR: %s\n", e)
@@ -302,7 +311,7 @@ def parselog(merge=False, filterlist=[]):
                     dirlist.remove(dir)
                     try:
                         if not args.test:
-                            os.utime(os.path.join(workdir, dir), (mtime, mtime))
+                            lutime(os.path.join(workdir, dir), (mtime, mtime))
                         dirs -= 1
                     except Exception as e:
                         logger.error("ERROR: %s\n", e)

--- a/git-restore-mtime-bare
+++ b/git-restore-mtime-bare
@@ -26,6 +26,14 @@
 import subprocess, shlex
 import sys, os.path
 
+if os.utime in getattr(os, 'supports_follow_symlinks', []):
+    def lutime(path, times):
+        os.utime(path, times, follow_symlinks=False)
+else:
+    def lutime(path, times):
+        if not os.path.islink(path):
+            os.utime(path, times)
+
 # List files matching user pathspec, relative to current directory
 filelist = set()
 for path in (sys.argv[1:] or [os.path.curdir]):
@@ -59,7 +67,7 @@ for line in gitobj.stdout:
         if file in filelist:
             filelist.remove(file)
             #print mtime, file
-            os.utime(file, (mtime, mtime))
+            lutime(file, (mtime, mtime))
 
     # Date line
     else:

--- a/git-restore-mtime-core
+++ b/git-restore-mtime-core
@@ -28,6 +28,15 @@ import logging as logger
 import argparse
 import time
 
+if os.utime in getattr(os, supports_follow_symlinks, []):
+    def lutime(path, times):
+        os.utime(path, times, follow_symlinks=False)
+else:
+    def lutime(path, times):
+        if os.path.islink(path):
+            raise Warning('Unable to update symlink: ' + path)
+        os.utime(path, times)
+
 parser = argparse.ArgumentParser(
     description='Restore original modification time of files based on '
                 'the date of the most recent commit that modified them. '
@@ -99,7 +108,7 @@ def parselog(merge=False, filterlist=[]):
                 logger.debug("%s\t%s", time.ctime(mtime), file)
                 filelist.remove(file)
                 try:
-                    os.utime(os.path.join(workdir, file), (mtime, mtime))
+                    lutime(os.path.join(workdir, file), (mtime, mtime))
                 except Exception as e:
                     logger.error("%s\n", e)
 


### PR DESCRIPTION
If we call os.utime on a symlink, the OS will normally dereference the
symlink and update the times on the target.

To avoid this, we pass follow_symlink=False, which only works on a
subset of python versions and operating systems. If it is not supported,
skip updating the symlink since the result is probably not desirable.

Fixes: #28