### PR TITLE
Add option to process log in reverse to git-restore-mtime.

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -125,6 +125,15 @@ def parse_args():
         action='store_true', default=False, dest='commit_time',
         help="Use commit time instead of author time")
 
+    parser.add_argument('--oldest-time', '-o',
+        action='store_true', default=False, dest='reverse_order',
+        help="""Set the mtime to the time of the first commit to mention a given file
+        instead of the most recent. This works by reversing the order in which the git
+        log is processed (i.e. from oldest to most recent commit on the current branch,
+        instead of from most recent to oldest). This may result in incorrect behaviour
+        if there are multiple files which have been renamed with the same name in the
+        current branch's history.""")
+
     parser.add_argument('pathspec', nargs='*', metavar='PATH',
         help="""Only modify paths matching PATH, directories or files, relative to current
         directory. Default is to modify all files handled by git, ignoring untracked files
@@ -213,10 +222,12 @@ class Git():
     def is_dirty(self):
         return bool(self._run('diff --no-ext-diff --quiet', output=False))
 
-    def log(self, merge=False, first_parent=False, commit_time=False, pathlist=None):
+    def log(self, merge=False, first_parent=False, commit_time=False, reverse_order=False,
+            pathlist=None):
         cmd = 'whatchanged --pretty={}'.format('%ct' if commit_time else '%at')
-        if merge:        cmd += ' -m'
-        if first_parent: cmd += ' --first-parent'
+        if merge:         cmd += ' -m'
+        if first_parent:  cmd += ' --first-parent'
+        if reverse_order: cmd += ' --reverse'
         return self._run(cmd, pathlist)
 
     def _repodirs(self):
@@ -245,7 +256,8 @@ class Git():
 
 def parselog(filelist, dirlist, stats, git, merge=False, filterlist=None):
     mtime = 0
-    for line in git.log(merge, args.first_parent, args.commit_time, filterlist):
+    for line in git.log(merge, args.first_parent, args.commit_time, args.reverse_order,
+            filterlist):
         stats['loglines'] += 1
 
         # Blank line between Date and list of files

--- a/man1/git-restore-mtime.1
+++ b/man1/git-restore-mtime.1
@@ -22,6 +22,7 @@ recent commit that modified them
 .RB [ --test ]
 .RB [ --commit-time ]
 .br
+.RB [ --oldest-commit ]
 .RB [ --work-tree
 .IR WORKDIR ]
 .RB [ --git-dir
@@ -85,6 +86,16 @@ updated.
 do not update directory mtime for files created,
 renamed or deleted in it. Note: just modifying a file
 will not update its directory mtime.
+.TP 8
+.BR \-\-oldest-commit , \-o
+pass --reverse to git whatchanged, so that the commit
+history for the current branch will be processed in
+reverse order (i.e. from the oldest commit to the most
+recent). This will result in a file's mtime being set
+to the time of the oldest commit to reference that
+file, instead of most recent. This option will not
+work correctly on branches where multiple files have
+been renamed with the same name.
 .TP 8
 .BR \-\-test , \-t
 test run: do not actually update any file


### PR DESCRIPTION
These commits add and document an `--oldest-commit` option for `git-restore-mtime`, which causes the change log to be processed in reverse order, from oldest commit to most recent. This causes file modification times to be set to the time of the *oldest* commit referencing that file instead of the most recent. (This won't work on branches which have multiple files which have been renamed to the same path, and is documented as such.)

My use case for this is ensuring that the `mtime` of the source files for articles in my blog engine are set to the original publication date (when they're first checked into git), even when they're edited after initial publication, as the RSS feed generator uses the source file `mtime` when generating the publication timestamp for an article.