### PR TITLE
fix debug output during trace

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -205,7 +205,7 @@ def parse_args():
     args_ = parser.parse_args()
     if args_.verbose:
         args_.loglevel = max(logging.TRACE, logging.DEBUG // args_.verbose)
-    args_.debug = args_.loglevel == logging.DEBUG
+    args_.debug = args_.loglevel <= logging.DEBUG
     return args_
 
 


### PR DESCRIPTION
It's a bit confusing that some output (that which is guarded by `args.debug`) is only present when running with a single `-v` but not with `-vv`. I suspect that wasn't the intention.