### PR TITLE
Fix non-ascii-paths errors in windows

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -345,7 +345,7 @@ class Git:
         if paths:
             cmdlist.append('--')
             cmdlist.extend(paths)
-        popen_args = dict(universal_newlines=True)
+        popen_args = dict(universal_newlines=True, encoding='utf8')
         if not self.errors:
             popen_args['stderr'] = subprocess.DEVNULL
         log.trace("Executing: %s", ' '.join(cmdlist))


### PR DESCRIPTION
The script git-restore-mtime is very useful to me, thank you very much.

This solution (preventively set encoding stdout to utf8) worked for me . Repositories with non-ascii-paths in Windows are handled perfectly.

With the original version I was getting errors:
```
ERROR: [WinError 2] The specified file cannot be found: 'C:\\demorep1\\РџСЂРёРІРµС‚.md': РџСЂРёРІРµС‚.md
```
or 
```
Traceback (most recent call last):
  File "C:\prog\git-tools\git-restore-mtime", line 594, in <module>
    sys.exit(main())
  File "C:\prog\git-tools\git-restore-mtime", line 489, in main
    for path in git.ls_files(args.pathspec):
  File "C:\prog\git-tools\git-restore-mtime", line 311, in <genexpr>
    return (normalize(_) for _ in self._run('ls-files --full-name', paths))
  File "C:\prog\git-tools\git-restore-mtime", line 361, in <genexpr>
    return (_.rstrip() for _ in self._proc.stdout)
  File "C:\Python3\lib\encodings\cp1251.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 889: character maps to <undefined>
```
