### PR TITLE
Bump minimum Python version to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requirements
 ------------
 
 - **Git** (duh!). Tested in v2.17.1 and prior versions since 2010
-- **Python** (for `git-restore-mtime`). Tested in Python 3.6, also works in Python 3.1+
+- **Python** (for `git-restore-mtime`). Requires Python 3.8 or later
 - **Bash** (for all other tools). Tested in Bash 4, some may work in Bash 3 or even `sh`
 
 Bash and Python are already installed by default in virtually all GNU/Linux distros.

--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -31,7 +31,6 @@ assuming the actual modification date and its commit date are close.
 
 # TODO:
 # - Add -z on git whatchanged/ls-files, so we don't deal with filename decoding
-# - When Python is bumped to 3.7, use text instead of universal_newlines on subprocess
 # - Update "Statistics for some large projects" with modern hardware and repositories.
 # - Create a README.md for git-restore-mtime alone. It deserves extensive documentation
 #   - Move Statistics there
@@ -75,6 +74,9 @@ import signal
 import subprocess
 import sys
 import time
+
+if sys.version_info < (3, 8):
+    sys.exit("Python 3.8 or later required.")
 
 __version__ = "2022.12+dev"
 
@@ -351,7 +353,7 @@ class Git:
         if paths:
             cmdlist.append('--')
             cmdlist.extend(paths)
-        popen_args = dict(universal_newlines=True, encoding='utf8')
+        popen_args = dict(text=True, encoding='utf8')
         if not self.errors:
             popen_args['stderr'] = subprocess.DEVNULL
         log.trace("Executing: %s", ' '.join(cmdlist))

--- a/windows/README.md
+++ b/windows/README.md
@@ -12,7 +12,7 @@ Requirements
 
 - **Windows**. Tested with Windows 8.1
 - **Git**. Tested in v2.17.1 and prior versions since 2010
-- **Python**. Tested in Python 3.8.0.
+- **Python**. Requires at least Python 3.8.0
 - **pip**. Tested with pip 19.3.1
 - **setuptools**. Tested with setuptools 42.0.0
 - **pyinstaller**. Tested with pyinstaller 4.0.dev0+1eadfa55f2


### PR DESCRIPTION
Implements the TODO regarding a python version bump by incorporating a version check outright. Now `universal_newlines` is only utilized if the version is earlier than 3.7, otherwise `text` is provided.