### PR TITLE
restore-mtime: Improve behavior of --first-parent

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -325,8 +325,15 @@ class Git:
     def log(self, merge=False, first_parent=False, commit_time=False,
             reverse_order=False, paths: list = None):
         cmd = 'whatchanged --pretty={}'.format('%ct' if commit_time else '%at')
-        if merge:         cmd += ' -m'
-        if first_parent:  cmd += ' --first-parent'
+
+        if merge:
+            if first_parent:
+                cmd += ' --diff-merges=first-parent --raw --first-parent'
+            else:
+                cmd += ' -m'
+        elif first_parent:
+            cmd += ' --first-parent'
+
         if reverse_order: cmd += ' --reverse'
         return self._run(cmd, paths)
 


### PR DESCRIPTION
Previously this flag was just passed to git whatchanged, but that doesn't seem to affect what files are listed on the merge commits. This uses --diff-merges=first-parent when both --merge and --first-parent are set. This way only files that are different from the first parent will get an updated timestamp.

This seems to align with the original goal of #21. Maybe there's a usecase I'm not thinking of where still using the full set of changed files from the merge commit makes sense. In that case I could also make this a separate option.

Our usecase is using the timestamps for rsync. For that case this is an improvement over just `-m` because it triggers less unnecessary timestamp changes (as long as the merges are in the right direction).

I'm not sure if the `elif` makes sense since when not evaluating merge commits it will just lead to changes coming from merges to be missed entirely.

`--diff-merges` seems to have been introduced in git 2.31 (I'm a bit confused because the release notes for 2.32 list it as well) so maybe the version in the README would have to be updated?