### PR TITLE
Ignore GPG signatures when parsing git logs

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -324,7 +324,7 @@ class Git:
 
     def log(self, merge=False, first_parent=False, commit_time=False,
             reverse_order=False, paths: list = None):
-        cmd = 'whatchanged --pretty={}'.format('%ct' if commit_time else '%at')
+        cmd = 'whatchanged --no-show-signature --pretty={}'.format('%ct' if commit_time else '%at')
         if merge:         cmd += ' -m'
         if first_parent:  cmd += ' --first-parent'
         if reverse_order: cmd += ' --reverse'

--- a/misc/git-restore-mtime-min
+++ b/misc/git-restore-mtime-min
@@ -22,7 +22,7 @@ for path in (sys.argv[1:] or [os.path.curdir]):
                 filelist.add(os.path.relpath(os.path.join(root, file)))
 
 mtime = 0
-gitobj = subprocess.Popen(shlex.split('git whatchanged --pretty=%at'),
+gitobj = subprocess.Popen(shlex.split('git whatchanged --no-show-signature --pretty=%at'),
                           stdout=subprocess.PIPE)
 for line in gitobj.stdout:
     line = line.strip()


### PR DESCRIPTION
In [Git v2.10](https://github.com/git/git/blob/v2.10.0/Documentation/RelNotes/2.10.0.txt#L70), the option [`log.showSignature`](https://git-scm.com/docs/git-log#Documentation/git-log.txt-logshowSignature) was introduced to imply a `--show-signature` flag for all calls to `log`, `show`, and `whatchanged`. If a user has this option enabled, and the most recent commit for any checked file was GPG-signed, this can lead to an uncaught exception when parsing the log, as instead of an expected author/commit time, the first line contains the GPG signature output.

```shell
$ git restore-mtime --version
git-restore-mtime version 2022.12

$ git restore-mtime
1 files to be processed in work dir
Traceback (most recent call last):
  File "/opt/homebrew/bin/git-restore-mtime", line 594, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/bin/git-restore-mtime", line 530, in main
    parse_log(filelist, dirlist, stats, git, args.merge, args.pathspec)
  File "/opt/homebrew/bin/git-restore-mtime", line 389, in parse_log
    mtime = int(line)
            ^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'gpg: Signature made Tue Sep 10 15:24:25 2024 EDT'
```

This fix simply enforces the `--no-show-signature` flag in the call to `git whatchanged` so that regardless of user config, GPG signatures are not checked and the first line of the returned string is indeed the commit timestamp.