### PR TITLE
git-restore-mtime: fix -N for symlinks

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -81,7 +81,7 @@ if sys.version_info < (3, 8):
 __version__ = "2022.12+dev"
 
 # Update symlinks only if the platform supports not following them
-UPDATE_SYMLINKS = bool({os.utime, os.stat} <= getattr(os, 'supports_follow_symlinks', {}))
+UPDATE_SYMLINKS = bool({os.utime, os.stat} <= getattr(os, 'supports_follow_symlinks', set()))
 
 # Call os.path.normpath() only if not in a POSIX platform (Windows)
 NORMALIZE_PATHS = (os.path.sep != '/')

--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -30,7 +30,7 @@ assuming the actual modification date and its commit date are close.
 """
 
 # TODO:
-# - Add -z on git whatchanged/ls-files, so we don't deal with filename decoding
+# - Add -z on git log/ls-files, so we don't deal with filename decoding
 # - Update "Statistics for some large projects" with modern hardware and repositories.
 # - Create a README.md for git-restore-mtime alone. It deserves extensive documentation
 #   - Move Statistics there
@@ -326,7 +326,7 @@ class Git:
 
     def log(self, merge=False, first_parent=False, commit_time=False,
             reverse_order=False, paths: list = None):
-        cmd = 'whatchanged --no-show-signature --pretty={}'.format('%ct' if commit_time else '%at')
+        cmd = 'log --raw --no-show-signature --pretty={}'.format('%ct' if commit_time else '%at')
         if merge:         cmd += ' -m'
         if first_parent:  cmd += ' --first-parent'
         if reverse_order: cmd += ' --reverse'

--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -81,7 +81,7 @@ if sys.version_info < (3, 8):
 __version__ = "2022.12+dev"
 
 # Update symlinks only if the platform supports not following them
-UPDATE_SYMLINKS = bool(os.utime in getattr(os, 'supports_follow_symlinks', []))
+UPDATE_SYMLINKS = bool({os.utime, os.stat} <= getattr(os, 'supports_follow_symlinks', {}))
 
 # Call os.path.normpath() only if not in a POSIX platform (Windows)
 NORMALIZE_PATHS = (os.path.sep != '/')
@@ -300,7 +300,7 @@ def get_mtime_ns(secs: int, idx: int):
 
 
 def get_mtime_path(path):
-    return os.path.getmtime(path)
+    return os.stat(path, **UTIME_KWS).st_mtime
 
 
 # Git class and parse_log(), the heart of the script ##########################


### PR DESCRIPTION
in the case of the symlink being older than the file it links to, `git-restore-mtime -N -v` was always changing the symlink timestamp

should i rename `UTIME_KWS` since it's used for `os.stat` now too?