### PR TITLE
Replace git-whatchanged usage with git-log

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -326,8 +326,8 @@ class Git:
 
     def log(self, merge=False, first_parent=False, commit_time=False,
             reverse_order=False, paths: list = None):
-        cmd = 'whatchanged --no-show-signature --pretty={}'.format('%ct' if commit_time else '%at')
-        if merge:         cmd += ' -m'
+        cmd = 'log --raw --no-show-signature --pretty={}'.format('%ct' if commit_time else '%at')
+        cmd += ' -m' if merge else ' --no-merges'
         if first_parent:  cmd += ' --first-parent'
         if reverse_order: cmd += ' --reverse'
         return self._run(cmd, paths)


### PR DESCRIPTION
`git-whatchanged` has been deprecated in Git 2.51 and now refuses to run without an override flag specified. According to the git-whatchanged documentation, it "is essentially the same as git-log(1) but defaults to showing the raw format diff output and skipping merges".

This patch replaces the usage of the `whatchanged` sub-command with `log`, passing `--raw` to preserve compatibility with previous behavior.

Addresses https://github.com/MestreLion/git-tools/issues/82