### PR TITLE
git-restore-mtime: git whatchanged has been deprecated in Git 2.51 

### DIFF
--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -326,7 +326,7 @@ class Git:
 
     def log(self, merge=False, first_parent=False, commit_time=False,
             reverse_order=False, paths: list = None):
-        cmd = 'whatchanged --no-show-signature --pretty={}'.format('%ct' if commit_time else '%at')
+        cmd = 'log --raw --no-show-signature --pretty={}'.format('%ct' if commit_time else '%at')
         if merge:         cmd += ' -m'
         if first_parent:  cmd += ' --first-parent'
         if reverse_order: cmd += ' --reverse'

--- a/misc/git-restore-mtime-min
+++ b/misc/git-restore-mtime-min
@@ -22,7 +22,7 @@ for path in (sys.argv[1:] or [os.path.curdir]):
                 filelist.add(os.path.relpath(os.path.join(root, file)))
 
 mtime = 0
-gitobj = subprocess.Popen(shlex.split('git whatchanged --no-show-signature --pretty=%at'),
+gitobj = subprocess.Popen(shlex.split('git log --raw --no-show-signature --pretty=%at'),
                           stdout=subprocess.PIPE)
 for line in gitobj.stdout:
     line = line.strip()


### PR DESCRIPTION
git-restore-mtime: git whatchanged has been deprecated in Git 2.51 and is scheduled for removal: git whatchanged -> git log --raw

Current documentation from https://git-scm.com/docs/git-whatchange specifies the suggested modification:
git whatchanged has been deprecated and is scheduled for removal in a future version of Git, as it is merely git log with different default; whatchanged is not even shorter to type than log --raw.
(..)
New users are encouraged to use git-log[1] instead. The whatchanged command is essentially the same as git-log[1] but defaults to showing the raw format diff output and skipping merges.
