### PR TITLE
Updated build_windows_executable.bat: use native Windows winget.exe in stead of chocolatey

### DIFF
--- a/windows/build_windows_executable.bat
+++ b/windows/build_windows_executable.bat
@@ -1,10 +1,13 @@
 @ECHO OFF
+PATH=C:\Program Files\Python313;C:\Program Files\Python313\Scripts;%PATH%
 IF "%1"=="/INIT" GOTO InitializeEnvironment
 PUSHD "%~dp0"
 
 ECHO.
 ECHO Checking current python.exe location(s)
 where python.exe
+where pip.exe
+where pyinstaller.exe
 
 ECHO.
 ECHO Version info for Python/pip/pyinstaller:
@@ -14,18 +17,20 @@ pyinstaller.exe --version
 
 ECHO.
 ECHO Testing if current git-restore-mtime Python script works...
-python.exe ..\git-restore-mtime --help
+python.exe ..\git-restore-mtime --version
 
 REM pyinstaller uses upx by default to compress the executable
 REM When running the created executable this results in an error:
 REM    git-restore-mtime.exe - Bad Image: %TEMP%\VCRUNTIME140.dll
 REM        is either not designed to run on Windows or it contains an error (..)
 REM Therefore run pyinstaller with the --noupx parameter
+ECHO.
+ECHO Running pyinstaller to create git-restore-mtime.exe...
 pyinstaller.exe -F --noupx ..\git-restore-mtime
 
 ECHO.
 ECHO Testing if git-restore-mtime.exe works...
-dist\git-restore-mtime.exe --help
+dist\git-restore-mtime.exe --version
 
 PAUSE
 GOTO :EOF
@@ -33,18 +38,12 @@ GOTO :EOF
 :InitializeEnvironment
 ECHO.
 ECHO NOTE: This script needs to run as administrator
-ECHO Press a key to install Chocolatey, Python and the required Python packages...
+ECHO Press a key to use Microsoft winget to install Python and the required Python packages...
 PAUSE
 
 ECHO.
-ECHO Installing/updating Chocolatey...
-@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass ^
-	-Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" ^
-&& SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
-
-ECHO.
 ECHO Installing/updating Python...
-choco.exe install -y python
+winget install --exact --id Python.Python.3.13 --scope machine --force --accept-package-agreements
 
 ECHO.
 ECHO Upgrading pip and setuptools to latest version...
@@ -53,7 +52,7 @@ pip.exe install --upgrade --trusted-host pypi.org --trusted-host files.pythonhos
 ECHO.
 ECHO Installing latest version of pyinstaller...
 pip.exe install --trusted-host pypi.org --trusted-host files.pythonhosted.org ^
-	https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
+  https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
 
 ECHO.
 ECHO Finished!

--- a/windows/build_windows_executable_INIT.bat
+++ b/windows/build_windows_executable_INIT.bat
@@ -1,0 +1,1 @@
+@CALL "%~dp0build_windows_executable.bat" /INIT


### PR DESCRIPTION
Updated build_windows_executable.bat: use native Windows winget.exe in stead of chocolatey

* Use native Windows winget.exe in stead of chocolatey; one-line chocolatey setup didn't seem to work properly anymore
* Specifically install Python 3.13 - with winget it seems a requirement to specify a specific version in stead of latest version
* Testing if current git-restore-mtime Python script works: just run --version in stead of --help
* Added build_windows_executable_INIT.bat to directly run the needed setups
* Added self elevation for the /INIT parameter
